### PR TITLE
Refactor for dry and comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021, John Moore
+Copyright (c) 2022, John Moore
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/_examples/bulk-time-in-status/main.go
+++ b/_examples/bulk-time-in-status/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/comments/main.go
+++ b/_examples/comments/main.go
@@ -28,7 +28,7 @@ func main() {
 		true,
 		os.Getenv("CLICKUP_WORKSPACE_ID"),
 	)
-	comment.BulletedListItem("Bullet Item 4", nil)
+	comment.BulletedListItem("Bullet Item 4asdf", nil)
 	comment.BulletedListItem("Bullet Item 5", nil)
 	comment.BulletedListItem("Bullet Item 6", &clickup.Attributes{Italic: true})
 	comment.NumberedListItem("Numbered Item 1", nil)

--- a/_examples/comments/main.go
+++ b/_examples/comments/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/create-attachment/main.go
+++ b/_examples/create-attachment/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/create-task/main.go
+++ b/_examples/create-task/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/get-folders/main.go
+++ b/_examples/get-folders/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/get-lists/main.go
+++ b/_examples/get-lists/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/get-spaces/main.go
+++ b/_examples/get-spaces/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/get-tasks/main.go
+++ b/_examples/get-tasks/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/time-in-status/main.go
+++ b/_examples/time-in-status/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/views/main.go
+++ b/_examples/views/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/_examples/webhooks/main.go
+++ b/_examples/webhooks/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/attachments.go
+++ b/attachments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/attachments_test.go
+++ b/attachments_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/authenticator.go
+++ b/authenticator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/client.go
+++ b/client.go
@@ -7,6 +7,10 @@
 package clickup
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -54,4 +58,57 @@ func NewClient(opts *ClientOpts) *Client {
 		authenticator: opts.Authenticator,
 		baseURL:       basePath,
 	}
+}
+
+func (c *Client) call(method, uri string, data *bytes.Buffer, result interface{}) error {
+	var req *http.Request
+	var err error
+
+	endpoint := fmt.Sprintf("%s%s", c.baseURL, uri)
+
+	switch method {
+	case http.MethodGet:
+		req, err = http.NewRequest(method, endpoint, nil)
+		if err != nil {
+			return err
+		}
+
+	case http.MethodPost:
+		req, err = http.NewRequest(method, endpoint, data)
+		req.Header.Add("Content-Type", "application/json")
+		if err != nil {
+			return err
+		}
+	case http.MethodPut:
+		req, err = http.NewRequest(method, endpoint, data)
+		req.Header.Add("Content-Type", "application/json")
+		if err != nil {
+			return err
+		}
+	case http.MethodDelete:
+		req, err = http.NewRequest(method, endpoint, nil)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported http method")
+	}
+
+	res, err := c.doer.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+
+	if res.StatusCode != http.StatusOK {
+		return errorFromResponse(res, decoder)
+	}
+
+	if err := decoder.Decode(result); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return nil
 }

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/client_doer.go
+++ b/client_doer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2022, John Moore
+// All rights reserved.
+
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+package clickup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type mockAuthenticator struct{}
+
+func (m *mockAuthenticator) AuthenticateFor(req *http.Request) error {
+	return errors.New("mock error")
+}
+
+func TestClient_call(t *testing.T) {
+	type fields struct {
+		doer          ClientDoer
+		authenticator Authenticator
+		baseURL       string
+	}
+	type args struct {
+		ctx    context.Context
+		method string
+		uri    string
+		data   *bytes.Buffer
+		result interface{}
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Success call",
+			fields: fields{
+				doer: newMockClientDoer(func(req *http.Request) (*http.Response, error) {
+					body := `{"lists":[{"id":"12345678","name":"Hippy Dippy List"}]}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       ioutil.NopCloser(strings.NewReader(body)),
+						Request:    req,
+					}, nil
+				}),
+				authenticator: &APITokenAuthenticator{},
+			},
+			args: args{
+				ctx:    context.Background(),
+				method: http.MethodGet,
+				uri:    "/list",
+				data:   nil,
+				result: &ListsResponse{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error for unsupported method",
+			fields: fields{
+				doer:          nil,
+				authenticator: &APITokenAuthenticator{},
+			},
+			args: args{
+				ctx:    context.Background(),
+				method: http.MethodPatch,
+				uri:    "/list",
+				data:   nil,
+				result: &ListsResponse{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error for authenticator failure",
+			fields: fields{
+				doer:          nil,
+				authenticator: &mockAuthenticator{},
+			},
+			args: args{
+				ctx:    context.Background(),
+				method: http.MethodGet,
+				uri:    "/list",
+				data:   nil,
+				result: &ListsResponse{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error for doer Do()",
+			fields: fields{
+				doer: newMockClientDoer(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("fake error")
+				}),
+				authenticator: &mockAuthenticator{},
+			},
+			args: args{
+				ctx:    context.Background(),
+				method: http.MethodGet,
+				uri:    "/list",
+				data:   nil,
+				result: &ListsResponse{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				doer:          tt.fields.doer,
+				authenticator: tt.fields.authenticator,
+				baseURL:       tt.fields.baseURL,
+			}
+			if err := c.call(tt.args.ctx, tt.args.method, tt.args.uri, tt.args.data, tt.args.result); (err != nil) != tt.wantErr {
+				t.Errorf("Client.call() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/comments.go
+++ b/comments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/comments.go
+++ b/comments.go
@@ -161,33 +161,12 @@ func (c *Client) CreateTaskComment(ctx context.Context, comment CreateTaskCommen
 	urlValues.Set("custom_task_ids", strconv.FormatBool(comment.UseCustomTaskIDs))
 	urlValues.Add("team_id", comment.WorkspaceID)
 
-	endpoint := fmt.Sprintf("%s/task/%s/comment/?%s", c.baseURL, comment.TaskID, urlValues.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return nil, fmt.Errorf("create task comment request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-	req.Header.Add("Content-type", "application/json")
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make create task comment request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/task/%s/comment/?%s", comment.TaskID, urlValues.Encode())
 
 	var commentResponse CreateTaskCommentResponse
 
-	if err := decoder.Decode(&commentResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse new task comment response: %w", err)
+	if err := c.call(ctx, http.MethodPost, endpoint, buf, &commentResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &commentResponse, nil
@@ -220,36 +199,16 @@ func (c *Client) CreateChatViewComment(ctx context.Context, comment CreateChatVi
 
 	buf := bytes.NewBuffer(b)
 
-	endpoint := fmt.Sprintf("%s/view/%s/comment", c.baseURL, comment.ViewID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return nil, fmt.Errorf("create view comment request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-	req.Header.Add("Content-type", "application/json")
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make create view comment request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/view/%s/comment", comment.ViewID)
 
 	var commentResponse CreateChatViewCommentResponse
 
-	if err := decoder.Decode(&commentResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse new view comment response: %w", err)
+	if err := c.call(ctx, http.MethodPost, endpoint, buf, &commentResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &commentResponse, nil
+
 }
 
 type CreateListCommentRequest struct {
@@ -279,33 +238,12 @@ func (c *Client) CreateListComment(ctx context.Context, comment CreateListCommen
 
 	buf := bytes.NewBuffer(b)
 
-	endpoint := fmt.Sprintf("%s/list/%s/comment", c.baseURL, comment.ListID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return nil, fmt.Errorf("create list comment request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-	req.Header.Add("Content-type", "application/json")
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make create list comment request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/list/%s/comment", comment.ListID)
 
 	var commentResponse CreateListCommentResponse
 
-	if err := decoder.Decode(&commentResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse new list comment response: %w", err)
+	if err := c.call(ctx, http.MethodPost, endpoint, buf, &commentResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &commentResponse, nil

--- a/comments_test.go
+++ b/comments_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/common_test.go
+++ b/common_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,7 @@ import (
 )
 
 var ErrValidation = errors.New("invalid input provided")
+var ErrCall = errors.New("failed to make request")
 
 type RateLimitError struct {
 	msg       string

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/folders.go
+++ b/folders.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/folders_test.go
+++ b/folders_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/lists.go
+++ b/lists.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/lists_test.go
+++ b/lists_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/mock_client_doer.go
+++ b/mock_client_doer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/spaces.go
+++ b/spaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/spaces.go
+++ b/spaces.go
@@ -8,7 +8,6 @@ package clickup
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -97,32 +96,12 @@ func (c *Client) SpacesForWorkspace(ctx context.Context, teamID string, includeA
 	urlValues := url.Values{}
 	urlValues.Set("archived", strconv.FormatBool(includeArchived))
 
-	endpoint := fmt.Sprintf("%s/team/%s/space/?%s", c.baseURL, teamID, urlValues.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("spaces request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make spaces request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/team/%s/space/?%s", teamID, urlValues.Encode())
 
 	var spacesResponse SpacesResponse
 
-	if err := decoder.Decode(&spacesResponse); err != nil {
-		return nil, fmt.Errorf("failed parse to spaces: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &spacesResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &spacesResponse, nil
@@ -130,32 +109,12 @@ func (c *Client) SpacesForWorkspace(ctx context.Context, teamID string, includeA
 
 func (c *Client) SpaceByID(ctx context.Context, spaceID string) (*SingleSpace, error) {
 
-	endpoint := fmt.Sprintf("%s/space/%s", c.baseURL, spaceID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("space request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make space request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/space/%s", spaceID)
 
 	var spaceResponse SingleSpace
 
-	if err := decoder.Decode(&spaceResponse); err != nil {
-		return nil, fmt.Errorf("failed parse to space: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &spaceResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &spaceResponse, nil

--- a/spaces_test.go
+++ b/spaces_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/tags.go
+++ b/tags.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/tags.go
+++ b/tags.go
@@ -26,32 +26,12 @@ type TagsQueryResponse struct {
 }
 
 func (c *Client) TagsForSpace(ctx context.Context, spaceID string) (*TagsQueryResponse, error) {
-	endpoint := fmt.Sprintf("%s/space/%s/tag", c.baseURL, spaceID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("tags for space request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make tags for spaces request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/space/%s/tag", spaceID)
 
 	var tagsResponse TagsQueryResponse
 
-	if err := decoder.Decode(&tagsResponse); err != nil {
-		return nil, fmt.Errorf("failed parse to tags response: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &tagsResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &tagsResponse, nil
@@ -67,30 +47,11 @@ func (c *Client) CreateSpaceTag(ctx context.Context, spaceID string, tag Tag) er
 	}
 	buf := bytes.NewBuffer(b)
 
-	endpoint := fmt.Sprintf("%s/space/%s/tag", c.baseURL, spaceID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return fmt.Errorf("create tag request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return fmt.Errorf("failed to authenticate client: %w", err)
-	}
+	endpoint := fmt.Sprintf("/space/%s/tag", spaceID)
 
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make create tag request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return errorFromResponse(res, decoder)
-	}
-
-	return nil
+	return c.call(ctx, http.MethodPost, endpoint, buf, &struct{}{})
 }
 
 func (c *Client) UpdateSpaceTag(ctx context.Context, spacID, tag Tag) error {
-	return nil
+	panic("TODO not implemented")
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/tasks.go
+++ b/tasks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/teams.go
+++ b/teams.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/teams.go
+++ b/teams.go
@@ -8,7 +8,6 @@ package clickup
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -44,32 +43,12 @@ type TeamMember struct {
 }
 
 func (c *Client) Teams(ctx context.Context) (*TeamsResponse, error) {
-	endpoint := fmt.Sprintf("%s/team", c.baseURL)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("get teams request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make teams request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/team")
 
 	var teamsResponse TeamsResponse
 
-	if err := decoder.Decode(&teamsResponse); err != nil {
-		return nil, fmt.Errorf("failed parse to teams response: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &teamsResponse); err != nil {
+		return nil, ErrCall
 	}
 
 	return &teamsResponse, nil

--- a/teams_test.go
+++ b/teams_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/views.go
+++ b/views.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/views.go
+++ b/views.go
@@ -8,7 +8,6 @@ package clickup
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -91,33 +90,12 @@ type TasksForViewResponse struct {
 }
 
 func (c *Client) ViewByID(ctx context.Context, viewID string) (*GetViewResponse, error) {
-	endpoint := fmt.Sprintf("%s/view/%s", c.baseURL, viewID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("view by id request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make view by id request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/view/%s", viewID)
 
 	var view GetViewResponse
 
-	if err := decoder.Decode(&view); err != nil {
-		return nil, fmt.Errorf("failed to parse view: %w", err)
-
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &view); err != nil {
+		return nil, ErrCall
 	}
 
 	return &view, nil
@@ -152,61 +130,19 @@ func (c *Client) ViewsFor(ctx context.Context, viewListType ViewListType, id str
 		return nil, errors.New("invalid ViewListType")
 	}
 
-	endpoint := fmt.Sprintf("%s/%s/%s/view", c.baseURL, viewsType, id)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("view request request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make views request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/%s/%s/view", viewsType, id)
 
 	var views GetViewsResponse
 
-	if err := decoder.Decode(&views); err != nil {
-		return nil, fmt.Errorf("failed to parse views: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &views); err != nil {
+		return nil, ErrCall
 	}
 
 	return &views, nil
 }
 
 func (c *Client) DeleteView(ctx context.Context, viewID string) error {
-	endpoint := fmt.Sprintf("%s/view/%s", c.baseURL, viewID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
-	if err != nil {
-		return fmt.Errorf("delete view request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make delete view request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return errorFromResponse(res, decoder)
-	}
-
-	return nil
+	return c.call(ctx, http.MethodPost, fmt.Sprintf("/view/%s", viewID), nil, &struct{}{})
 }
 
 // TasksForView requires possible pagination.  Clickup documents that a page will have a
@@ -216,32 +152,12 @@ func (c *Client) TasksForView(ctx context.Context, viewID string, page int) (*Ta
 	urlValues := url.Values{}
 	urlValues.Set("page", strconv.Itoa(page))
 
-	endpoint := fmt.Sprintf("%s/view/%s/task/?%s", c.baseURL, viewID, urlValues.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("tasks for view request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make tasks for view request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/view/%s/task/?%s", viewID, urlValues.Encode())
 
 	var tasks TasksForViewResponse
 
-	if err := decoder.Decode(&tasks); err != nil {
-		return nil, fmt.Errorf("failed to parse tasks: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &tasks); err != nil {
+		return nil, ErrCall
 	}
 
 	return &tasks, nil

--- a/webhooks.go
+++ b/webhooks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, John Moore
+// Copyright (c) 2022, John Moore
 // All rights reserved.
 
 // This source code is licensed under the BSD-style license found in the

--- a/webhooks.go
+++ b/webhooks.go
@@ -110,33 +110,12 @@ func (c *Client) CreateWebhook(ctx context.Context, workspaceID string, webhook 
 	}
 	buf := bytes.NewBuffer(b)
 
-	endpoint := fmt.Sprintf("%s/team/%s/webhook", c.baseURL, workspaceID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return nil, fmt.Errorf("create task request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-	req.Header.Add("Content-type", "application/json")
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make create webhook request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/team/%s/webhook", workspaceID)
 
 	var newWebhook CreateWebhookResponse
 
-	if err := decoder.Decode(&newWebhook); err != nil {
-		return nil, fmt.Errorf("failed to parse new webhook - WARNING! WEBHOOK MIGHT HAVE BEEN CREATED: %w", err)
+	if err := c.call(ctx, http.MethodPost, endpoint, buf, &newWebhook); err != nil {
+		return nil, ErrCall
 	}
 
 	return &newWebhook, nil
@@ -163,92 +142,29 @@ func (c *Client) UpdateWebhook(ctx context.Context, webhook *UpdateWebhookReques
 	}
 	buf := bytes.NewBuffer(b)
 
-	endpoint := fmt.Sprintf("%s/webhook/%s", c.baseURL, webhook.ID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, buf)
-	if err != nil {
-		return nil, fmt.Errorf("create task request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-	req.Header.Add("Content-type", "application/json")
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make update webhook request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/webhook/%s", webhook.ID)
 
 	var updatedWebhook UpdateWebhookResponse
 
-	if err := decoder.Decode(&updatedWebhook); err != nil {
-		return nil, fmt.Errorf("failed to parse webhook: %w", err)
+	if err := c.call(ctx, http.MethodPut, endpoint, buf, &updatedWebhook); err != nil {
+		return nil, ErrCall
 	}
 
 	return &updatedWebhook, nil
 }
 
 func (c *Client) DeleteWebhook(ctx context.Context, id string) error {
-	endpoint := fmt.Sprintf("%s/webhook/%s", c.baseURL, id)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
-	if err != nil {
-		return fmt.Errorf("webhooks delete request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make delete webhooks request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return errorFromResponse(res, decoder)
-	}
-
-	return nil
+	return c.call(ctx, http.MethodGet, fmt.Sprintf("/webhook/%s", id), nil, &struct{}{})
 }
 
 func (c *Client) WebhooksFor(ctx context.Context, workspaceID string) (*WebhooksQueryResponse, error) {
 
-	endpoint := fmt.Sprintf("%s/team/%s/webhook", c.baseURL, workspaceID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("webhooks request failed: %w", err)
-	}
-	if err := c.AuthenticateFor(req); err != nil {
-		return nil, fmt.Errorf("failed to authenticate client: %w", err)
-	}
-
-	res, err := c.doer.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make get webhooks request: %w", err)
-	}
-	defer res.Body.Close()
-
-	decoder := json.NewDecoder(res.Body)
-
-	if res.StatusCode != http.StatusOK {
-		return nil, errorFromResponse(res, decoder)
-	}
+	endpoint := fmt.Sprintf("/team/%s/webhook", workspaceID)
 
 	var webhooks WebhooksQueryResponse
 
-	if err := decoder.Decode(&webhooks); err != nil {
-		return nil, fmt.Errorf("failed to parse webhooks: %w", err)
+	if err := c.call(ctx, http.MethodGet, endpoint, nil, &webhooks); err != nil {
+		return nil, ErrCall
 	}
 
 	return &webhooks, nil


### PR DESCRIPTION
I originally had a lot of redundant code because the clickup API is a bit inconsistent.  With some introduced common error handling and such, I think it's in a good place to introduce this unexported client method that brokers the api calls.