### PR TITLE
Use DELETE method for DeleteWebhook.

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -249,7 +249,7 @@ func (c *Client) DeleteWebhook(ctx context.Context, webhookID string) error {
 	if webhookID == "" {
 		return fmt.Errorf("must provide a webhook id to delete: %w", ErrValidation)
 	}
-	return c.call(ctx, http.MethodGet, fmt.Sprintf("/webhook/%s", webhookID), nil, &struct{}{})
+	return c.call(ctx, http.MethodDelete, fmt.Sprintf("/webhook/%s", webhookID), nil, &struct{}{})
 }
 
 // WebhooksFor returns a listing of all webhooks for a workspace.

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -159,6 +159,14 @@ func TestClient_DeleteWebhook(t *testing.T) {
 			name: "Success webhook id provided",
 			fields: fields{
 				doer: newMockClientDoer(func(req *http.Request) (*http.Response, error) {
+					if req.Method != http.MethodDelete {
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       ioutil.NopCloser(strings.NewReader("")),
+							Request:    req,
+						}, nil
+					}
+
 					body := `{}`
 					return &http.Response{
 						StatusCode: http.StatusOK,
@@ -248,7 +256,8 @@ func TestClient_UpdateWebhook(t *testing.T) {
 				webhook: &UpdateWebhookRequest{
 					ID:       "",
 					Endpoint: "https://endpoint.clickup",
-				}},
+				},
+			},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
`(*Client).DeleteWebhook()` was sending a `GET` request, rather than a `DELETE`.

1. Added logic to unit test for this scenario.
2. Corrected the HTTP method.